### PR TITLE
feat: add basic map editor

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -78,6 +78,10 @@
   const createRoomName = document.getElementById('createRoomName');
   const createRoomMap = document.getElementById('createRoomMap');
   const createRoomMaxPlayers = document.getElementById('createRoomMaxPlayers');
+
+  // Map editor elements
+  const mapEditorButton = document.getElementById('mapEditorButton');
+  const mapEditorContainer = document.getElementById('mapEditorContainer');
   const maxPlayersValue = document.getElementById('maxPlayersValue');
   const createRoomPrivate = document.getElementById('createRoomPrivate');
   const createRoomButton = document.getElementById('createRoomButton');
@@ -454,6 +458,18 @@
   quickJoinButton.addEventListener('click', handleQuickJoin);
   refreshRoomsButton.addEventListener('click', loadRooms);
   createRoomButton.addEventListener('click', handleCreateRoom);
+
+  // Map editor button
+  mapEditorButton.addEventListener('click', () => {
+    if (socket && socket.connected) {
+      socket.disconnect();
+    }
+    menu.classList.add('hidden');
+    mapEditorContainer.classList.remove('hidden');
+    if (typeof initMapEditor === 'function') {
+      initMapEditor();
+    }
+  });
   
   // Close room browser when clicking outside modal
   roomBrowserModal.addEventListener('click', (e) => {

--- a/client/index.html
+++ b/client/index.html
@@ -158,6 +158,9 @@
     
     <!-- Room Browser Button -->
     <button id="roomBrowserButton" class="room-browser-button">Browse Rooms</button>
+
+    <!-- Map Editor Button -->
+    <button id="mapEditorButton" class="map-editor-button">Map Editor</button>
   </div>
 
   <canvas id="spectatorCanvas" class="spectator-canvas"></canvas>
@@ -491,9 +494,21 @@
         </div>
       </div>
 
+  </div>
+  </div>
+
+  <!-- Map Editor Overlay -->
+  <div id="mapEditorContainer" class="map-editor-container hidden">
+    <div class="map-editor-sidebar">
+      <select id="mapSelect"></select>
+      <button id="applyMapData">Apply JSON</button>
+      <button id="downloadMapData">Download JSON</button>
+      <textarea id="mapDataInput" class="map-editor-text"></textarea>
     </div>
+    <canvas id="mapEditorCanvas" class="map-editor-canvas"></canvas>
   </div>
 
   <script src="client.js"></script>
+  <script src="mapEditor.js"></script>
 </body>
 </html>

--- a/client/mapEditor.js
+++ b/client/mapEditor.js
@@ -1,0 +1,139 @@
+let editorCanvas, editorCtx;
+let editorMap = null;
+
+function initMapEditor() {
+  editorCanvas = document.getElementById('mapEditorCanvas');
+  editorCtx = editorCanvas.getContext('2d');
+  resizeEditorCanvas();
+
+  // load maps list
+  fetch('/api/maps')
+    .then(res => res.json())
+    .then(maps => {
+      const select = document.getElementById('mapSelect');
+      select.innerHTML = maps.map(m => `<option value="${m.key}">${m.name}</option>`).join('');
+      if (maps.length) {
+        loadMap(maps[0].key);
+      }
+    });
+
+  document.getElementById('mapSelect').addEventListener('change', e => {
+    loadMap(e.target.value);
+  });
+
+  document.getElementById('applyMapData').addEventListener('click', () => {
+    try {
+      const data = JSON.parse(document.getElementById('mapDataInput').value);
+      editorMap = data;
+      renderEditor();
+    } catch (err) {
+      alert('Invalid JSON');
+    }
+  });
+
+  document.getElementById('downloadMapData').addEventListener('click', () => {
+    if (!editorMap) return;
+    const blob = new Blob([JSON.stringify(editorMap, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'map.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  window.addEventListener('resize', resizeEditorCanvas);
+}
+
+function resizeEditorCanvas() {
+  if (!editorCanvas) return;
+  editorCanvas.width = window.innerWidth;
+  editorCanvas.height = window.innerHeight;
+  renderEditor();
+}
+
+function loadMap(key) {
+  fetch(`/api/maps/${key}`)
+    .then(res => res.json())
+    .then(data => {
+      editorMap = data;
+      document.getElementById('mapDataInput').value = JSON.stringify(data, null, 2);
+      renderEditor();
+    });
+}
+
+function renderEditor() {
+  if (!editorCanvas || !editorCtx) return;
+  editorCtx.clearRect(0, 0, editorCanvas.width, editorCanvas.height);
+  if (!editorMap) return;
+
+  editorCtx.save();
+  editorCtx.translate(editorCanvas.width / 2, editorCanvas.height / 2);
+
+  // draw shapes
+  if (Array.isArray(editorMap.shapes)) {
+    editorMap.shapes.forEach(shape => {
+      if (!Array.isArray(shape.vertices)) return;
+      editorCtx.beginPath();
+      editorCtx.moveTo(shape.vertices[0].x, -shape.vertices[0].y);
+      for (let i = 1; i < shape.vertices.length; i++) {
+        editorCtx.lineTo(shape.vertices[i].x, -shape.vertices[i].y);
+      }
+      editorCtx.closePath();
+      if (Array.isArray(shape.fillColor)) {
+        editorCtx.fillStyle = `rgb(${shape.fillColor[0]},${shape.fillColor[1]},${shape.fillColor[2]})`;
+      } else {
+        editorCtx.fillStyle = '#555';
+      }
+      editorCtx.fill();
+    });
+  }
+
+  // start area
+  if (editorMap.start && Array.isArray(editorMap.start.vertices)) {
+    editorCtx.strokeStyle = '#0f0';
+    editorCtx.beginPath();
+    const verts = editorMap.start.vertices;
+    editorCtx.moveTo(verts[0].x, -verts[0].y);
+    for (let i = 1; i < verts.length; i++) editorCtx.lineTo(verts[i].x, -verts[i].y);
+    editorCtx.closePath();
+    editorCtx.stroke();
+  }
+
+  // checkpoints
+  if (Array.isArray(editorMap.checkpoints)) {
+    editorCtx.strokeStyle = '#ff0';
+    editorMap.checkpoints.forEach(cp => {
+      if (Array.isArray(cp.vertices) && cp.vertices.length >= 2) {
+        editorCtx.beginPath();
+        editorCtx.moveTo(cp.vertices[0].x, -cp.vertices[0].y);
+        editorCtx.lineTo(cp.vertices[1].x, -cp.vertices[1].y);
+        editorCtx.stroke();
+      }
+    });
+  }
+
+  // dynamic objects
+  if (Array.isArray(editorMap.dynamicObjects)) {
+    editorCtx.fillStyle = '#f0f';
+    editorMap.dynamicObjects.forEach(obj => {
+      if (obj.type === 'circle') {
+        editorCtx.beginPath();
+        editorCtx.arc(obj.x || 0, -(obj.y || 0), obj.radius || 10, 0, Math.PI * 2);
+        editorCtx.fill();
+      } else if (Array.isArray(obj.vertices)) {
+        editorCtx.beginPath();
+        editorCtx.moveTo(obj.vertices[0].x, -obj.vertices[0].y);
+        for (let i = 1; i < obj.vertices.length; i++) {
+          editorCtx.lineTo(obj.vertices[i].x, -obj.vertices[i].y);
+        }
+        editorCtx.closePath();
+        editorCtx.fill();
+      }
+    });
+  }
+
+  editorCtx.restore();
+}
+
+window.initMapEditor = initMapEditor;

--- a/client/style.css
+++ b/client/style.css
@@ -2451,7 +2451,61 @@ input[type="number"]:focus {
     gap: 10px;
   }
   
-  .toolbar-hover-zone {
+.toolbar-hover-zone {
     height: 60px;
   }
+}
+
+/* Map Editor */
+.map-editor-button {
+  background: #5f8fff;
+  border: none;
+  color: #ffffff;
+  padding: 12px 24px;
+  font-size: 1rem;
+  font-weight: 600;
+  font-family: 'Overpass', sans-serif;
+  cursor: pointer;
+  margin-top: 1rem;
+  transition: all 0.3s ease;
+}
+
+.map-editor-button:hover {
+  background: #b6b6b6;
+  transform: translateY(-2px);
+}
+
+.map-editor-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  background: #1a1a1a;
+  color: #ffffff;
+  z-index: 1000;
+}
+
+.map-editor-sidebar {
+  width: 300px;
+  padding: 20px;
+  box-sizing: border-box;
+  background: #222222;
+  overflow-y: auto;
+}
+
+.map-editor-canvas {
+  flex: 1;
+  background: #000000;
+}
+
+.map-editor-text {
+  width: 100%;
+  height: 200px;
+  margin-top: 10px;
+  background: #111;
+  color: #0f0;
+  font-family: monospace;
+  font-size: 12px;
 }

--- a/server.js
+++ b/server.js
@@ -51,6 +51,17 @@ app.get('/api/maps', (req, res) => {
   res.json(mapList);
 });
 
+// send full map data to client for editor
+app.get('/api/maps/:key', (req, res) => {
+  const key = req.params.key;
+  const map = MAP_TYPES[key];
+  if (map) {
+    res.json(map);
+  } else {
+    res.status(404).json({ error: 'Map not found' });
+  }
+});
+
 // send debug mode status to client
 app.get('/api/debug', (req, res) => {
   res.json({ debugMode: DEBUG_MODE });


### PR DESCRIPTION
## Summary
- add map editor button to menu and UI overlay
- serve full map data via new API endpoint
- implement simple JSON-based map editor with live preview

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68a39b80dda0832eaa2dcfc997b8f8ea